### PR TITLE
feat: Challenge and rank tests

### DIFF
--- a/app/Http/Resources/V1/ChallengeResource.php
+++ b/app/Http/Resources/V1/ChallengeResource.php
@@ -4,28 +4,42 @@ namespace App\Http\Resources\V1;
 
 use App\Constants\ChallengeStatuses;
 use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
 
 class ChallengeResource extends JsonResource
 {
     public function toArray($request): array
     {
+        $max = $request->query('max', 10);
         return [
             'id' => $this->id,
             'name' => $this->name,
             'description' => $this->description,
-            'challengers_has_completed' => $this->getChallengersHasCompleted()
+            'time_out' => $this->time_out,
+            'challengers_has_completed' => $this->getChallengersHasCompleted($max),
         ];
     }
 
-    private function getChallengersHasCompleted()
+    private function getChallengersHasCompleted($max): Collection
     {
-        return $this->challengers->where('pivot.status', ChallengeStatuses::COMPLETE)
-            ->map(function ($challenger) {
-                return [
-                    'nick_name' => $challenger->user->nick_name,
-                    'points' => $challenger->points,
-                    'rank' => $challenger->rank->name
-                ];
-            });
+        $challenger_has_completed = DB::table('challenge_activity_logs')->where('challenge_id', $this->id)
+            ->where('challenge_id', '=', $this->id)
+            ->join('challengers', 'challengers.id', '=', 'challenge_activity_logs.challenger_id')
+            ->join('users', 'users.id', '=', 'challengers.user_id')
+            ->join('ranks', 'ranks.id', '=', 'challengers.rank_id')
+            ->select('users.nick_name as user', 'points', 'ranks.name as rank')
+            ->limit($max)
+            ->get();
+
+        return $challenger_has_completed->map(function ($challenger) {
+            return [
+                'challenger' => $challenger->user,
+                'points' => $challenger->points,
+                'rank' => $challenger->rank
+            ];
+        });
+
+
     }
 }

--- a/app/Http/Resources/V1/RankResource.php
+++ b/app/Http/Resources/V1/RankResource.php
@@ -15,6 +15,7 @@ class RankResource extends JsonResource
             'name' => $this->name,
             'required_points' => $this->required_points,
             'created_at' => $this->created_at,
+            'updated_at' => $this->updated_at,
         ];
     }
 }

--- a/tests/Feature/Api/V1/ChallengesControllerTest.php
+++ b/tests/Feature/Api/V1/ChallengesControllerTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Tests\Feature\Api\V1;
+
+use App\Models\Challenge;
+use App\Models\Challenger;
+use App\Models\Rank;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ChallengesControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * Test endpoint "/api/v1/challenges"
+     *
+     * @return void
+     */
+    public function test_get_challenges()
+    {
+
+        $response = $this->get('/api/v1/challenges');
+        $response->assertStatus(200);
+        $response->assertJsonStructure(["data"]);
+    }
+
+    /**
+     * Test endpoint "/api/v1/challenges/{id}"
+     *
+     * @return void
+     */
+    public function test_get_challenge()
+    {
+
+        //Create necessary user, challenger, challenge and rank to test json structure
+        $user = User::factory()->create();
+        $rank = Rank::factory()->create();
+        $challenger = Challenger::create(
+            ['user_id' => $user->id, 'rank_id' => $rank->id]
+        );
+
+        $challenge = Challenge::factory(1)->create();
+
+
+        //Attach challenger to challenge to test a correct json response
+        $challenger->challenges()->attach($challenge);
+        $response = $this->get('/api/v1/challenges/1');
+        $response->assertStatus(200);
+        $response->assertJsonStructure(["data" => [
+            'id',
+            'name',
+            'description',
+            'time_out',
+            'challengers_has_completed' => [['challenger', 'points', 'rank']],
+        ]]);
+    }
+}

--- a/tests/Feature/Api/V1/RankControllerTest.php
+++ b/tests/Feature/Api/V1/RankControllerTest.php
@@ -19,7 +19,7 @@ class RankControllerTest extends TestCase
     public function test_get_ranks()
     {
 
-        $response = $this->get('/api/V1/ranks');
+        $response = $this->get('/api/v1/ranks');
         $response->assertStatus(200);
         $response->assertJsonStructure([
             'data',
@@ -30,18 +30,16 @@ class RankControllerTest extends TestCase
     public function test_get_rank()
     {
         $rank = Rank::factory()->create();
-        $response = $this->get('/api/V1/ranks/' . $rank->id);
+        $response = $this->get('/api/v1/ranks/' . $rank->id);
         $response->assertJsonStructure([
             'data' => [
                 'id',
                 'name',
                 'required_points',
                 'created_at',
-                'updated_at',
+                'updated_at'
             ],
         ]);
         $response->assertStatus(200);
-
     }
-
 }


### PR DESCRIPTION
#### **Challenges and ranks tested, each model has its own get and get all tests**

Extra changes:
- ChallengeResource updated
- RankResoruce Small update

Challenge Resource was a little dangerous if we got many challengers who has completed it. 
In order to resolve this issue, I have created a query parameter, which allows frontend programers to limit the number of challengers taken for each challenge. 

I mean:

`/api/v1/challenges/1?max=15`
It will return max 15 challengers in  `challengers_have_completed`
![OnPaste 20211229-193652](https://user-images.githubusercontent.com/52052247/147714847-31c51ee0-b637-4ba2-afc5-07b8c8c987d7.png)









<!-- Thanks so much for your PR, your contribution is appreciated! -->

## Checklist ✅

- [x] I have followed the [contributor guideline](https://github.com/Platzi-Master-C8/gethired-base/blob/main/CONTRIBUTING.md)
- [x] Tests are included
- [x] Documentation is changed or added
- [x] Related issue has been created
- [x] Commits messages follows [commit guideline](https://github.com/Platzi-Master-C8/gethired-base/blob/main/CONTRIBUTING.md/#Commits)


#25 



