### PR TITLE
Feature 40

### DIFF
--- a/app/Constants/AvailableDockerLanguages.php
+++ b/app/Constants/AvailableDockerLanguages.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Constants;
+
+class AvailableDockerLanguages implements IConstant
+{
+    const JS = 'javascript';
+    const PHP = 'php';
+
+    public static function toArray(): array
+    {
+        return [
+            self::JS,
+            self::PHP,
+        ];
+    }
+}

--- a/app/DockerFiles/NodeJs/Dockerfile
+++ b/app/DockerFiles/NodeJs/Dockerfile
@@ -6,5 +6,4 @@ COPY package*.json ./
 
 RUN npm install
 
-EXPOSE 8081
 ENTRYPOINT ["tail", "-f", "/dev/null"]

--- a/app/Http/Controllers/CodeRunnerController.php
+++ b/app/Http/Controllers/CodeRunnerController.php
@@ -17,13 +17,9 @@ use App\Util\StorageWriter;
 
 class CodeRunnerController extends Controller
 {
-
-    //Start docker if not running
     /**
      * @param Challenge $challenge
      * @return false|string
-     *
-     *
      */
     public function getChallengeEditor(Challenge $challenge)
     {
@@ -85,7 +81,7 @@ class CodeRunnerController extends Controller
         // We have to stop containers with Async in order to get server response faster
 
         //        $stopCommand = "docker stop docker-$userIdentifier";
-        //        shell_exec($stopCommand);
+        //        shell_exec($s topCommand);
 
 
         $json = JsonTestParser::parse(json_decode($result), AvailableDockerLanguages::JS);

--- a/app/Http/Controllers/CodeRunnerController.php
+++ b/app/Http/Controllers/CodeRunnerController.php
@@ -2,11 +2,14 @@
 
 namespace App\Http\Controllers;
 
+use App\Constants\AvailableDockerLanguages;
 use App\Constants\DockerChallengesPaths;
 use App\Constants\DockerImagesNames;
 use App\Constants\LocalChallengesPaths;
 use App\Constants\StorageDisks;
 use App\Models\Challenge;
+use App\Util\JsonTestParser;
+use Exception;
 use Illuminate\Contracts\Filesystem\FileNotFoundException;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
@@ -51,6 +54,9 @@ class CodeRunnerController extends Controller
     }
 
 
+    /**
+     * @throws Exception in case  JsonTestParser::parse receives a non-supported language
+     */
     public function runNode(Request $request, Challenge $challenge): array
     {
         $userIdentifier = $this->getUserIdentifier();
@@ -63,6 +69,7 @@ class CodeRunnerController extends Controller
 
         //Clean test file or create if not exist
         $writer->write("test.json", '');
+        //This should be replaced with docker class
         $command = "docker exec docker-$userIdentifier  sh -c 'npm run test tests/$challenge->id/$userIdentifier/func.test.js -- --json"
             . "> tests/$challenge->id/$userIdentifier/test.json'";
 
@@ -75,19 +82,20 @@ class CodeRunnerController extends Controller
         } catch (FileNotFoundException $e) {
             $result = '{"passed": false, "message": "Server error"}';
         }
-// With Async we'll have to stop container, to get server response faster
-//        $stopCommand = "docker stop docker-$userIdentifier";
-//        shell_exec($stopCommand);
+        // We have to stop containers with Async in order to get server response faster
+
+        //        $stopCommand = "docker stop docker-$userIdentifier";
+        //        shell_exec($stopCommand);
 
 
-        return ['test_result' => json_decode($result),
+        $json = JsonTestParser::parse(json_decode($result), AvailableDockerLanguages::JS);
+        return ['test_result' => $json,
             'template' => $request->code];
     }
 
-
     /**
      * @return string
-     * Return a identifier to have always the same path for user tests
+     * Return user identifier to have always the same path for user tests
      */
     private function getUserIdentifier(): string
     {

--- a/app/Util/JsonTestParser.php
+++ b/app/Util/JsonTestParser.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Util;
+
+use App\Constants\AvailableDockerLanguages;
+use Exception;
+
+class JsonTestParser
+{
+    /**
+     * @param $json : Complex array with json data
+     * @param $language : Language of the test, use App\Constants\AvailableDockerLanguages
+     * @throws Exception : If the language is not supported
+     */
+    public static function parse($json, string $language): array
+    {
+        $availableLanguages = AvailableDockerLanguages::toArray();
+
+        if (!in_array($language, $availableLanguages)) {
+            throw new Exception('Language not supported');
+        }
+        switch ($language) {
+            case AvailableDockerLanguages::JS:
+                return self::parseJs($json);
+            case AvailableDockerLanguages::PHP:
+                return self::parsePhp($json);
+            default:
+                throw new Exception('Switch is not handling all available languages, fix it!');
+        }
+    }
+
+    private static function parseJs($json): array
+    {
+        $data['message'] = $json->testResults[0]->message;
+        $data['status'] = $json->testResults[0]->status;
+
+        return $data;
+    }
+
+    private static function parsePhp($json): array
+    {
+
+        /*Todo: We could implement php test in the future, we know how phpunit works, so it would be very easy for us*/
+        return [];
+    }
+}

--- a/app/Util/JsonTestParser.php
+++ b/app/Util/JsonTestParser.php
@@ -33,13 +33,22 @@ class JsonTestParser
     {
         $data['message'] = $json->testResults[0]->message;
         $data['status'] = $json->testResults[0]->status;
+        $data['tests'] = array_map(function ($assertion) {
+            return [
+                'name' => $assertion->title,
+                'test_status' => $assertion->status,
+                'failure_messages' => $assertion->failureMessages,
+            ];
+        }, $json->testResults[0]->assertionResults);
+
+        $data['tests_passed'] = $json->numPassedTests;
+        $data['tests_failed'] = $json->numFailedTests;
 
         return $data;
     }
 
     private static function parsePhp($json): array
     {
-
         /*Todo: We could implement php test in the future, we know how phpunit works, so it would be very easy for us*/
         return [];
     }

--- a/database/seeders/ChallengeSeeder.php
+++ b/database/seeders/ChallengeSeeder.php
@@ -54,11 +54,11 @@ class ChallengeSeeder extends Seeder
             "description" => "Create a function that returns the sum of a + b",
             "time_out" => 45,
             "difficulty" => ChallengeDifficulties::LOW,
-            'func_template' => "
-            const func = require('./user_func.js');
-            function sum(a,b){\n\t/*Your code here*/\n}" .
+            'func_template' => "function sum(a,b){\n\t/*Your code here*/\n}" .
                 "\nmodule.exports=sum;",
-            'test_template' => "test('adds 1 + 2 to equal 3', () => {
+
+            'test_template' => "const func = require('./user_func.js');
+            test('adds 1 + 2 to equal 3', () => {
     expect(func(1, 2)).toBe(3);
 });"
         ]);


### PR DESCRIPTION
# Json parsed on frontend requirements



json structure delivered in this point
- test_result
  - message
  - status
  - tests
    - name
    - test_status
    - failure_message
  - test_passed
  - test_failed


### New classes:
App\Util\TestJsonParser
**Following a one-entry point pattern, this class is in charge of parsing the JSON result, gotta receive a supported language, defined in App\Util\AvailableDockerLanguages**

#### Hotfix:
This **PR** also has a  hotfix for #39 
Added a missed line in a challenge test dummy in seeders.
It was causing that the code runner would not able to test the user functions.
<!-- Thanks so much for your PR, your contribution is appreciated! -->

## Checklist ✅

- [X] I have followed the [contributor guideline](https://github.com/Platzi-Master-C8/gethired-base/blob/main/CONTRIBUTING.md)
- [ ] Tests are included
- [X] Documentation is changed or added
- [X] Related issue has been created
- [X] Commits messages follows [commit guideline](https://github.com/Platzi-Master-C8/gethired-base/blob/main/CONTRIBUTING.md/#Commits)

resolves #40

<!-- Replace [Issue ID] with the issue id -->