### PR TITLE
feat: Test and request for challenges store

### DIFF
--- a/app/Http/Controllers/Api/V1/ChallengeController.php
+++ b/app/Http/Controllers/Api/V1/ChallengeController.php
@@ -3,8 +3,8 @@
 namespace App\Http\Controllers\Api\V1;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\Api\v1\StoreChallengeRequest;
 use App\Models\Challenge;
-use Illuminate\Http\Request;
 use App\Http\Resources\V1\ChallengeResource;
 use App\Http\Resources\V1\ChallengeCollection;
 
@@ -25,6 +25,13 @@ class ChallengeController extends Controller
         return Challenge::find($challengerId);
     }
 
-
+    public function store(StoreChallengeRequest $request)
+    {
+        $request->validated();
+        if ($request->token != env('STORE_CHALLENGES_TOKEN')) {
+            return response()->json(['error' => 'Unauthorized'], 401);
+        }
+        $challenge = Challenge::create($request->all());
+        return new ChallengeResource($challenge);
+    }
 }
-

--- a/app/Http/Controllers/CodeRunnerController.php
+++ b/app/Http/Controllers/CodeRunnerController.php
@@ -30,8 +30,8 @@ class CodeRunnerController extends Controller
         $userIdentifier = $this->getUserIdentifier();
 
         $docker = new DockerContainer("node-" . $userIdentifier, DockerImagesNames::NODE_IMAGE);
-        $docker->bindMount(storage_path(LocalChallengesPaths::NODE_PATH), DockerChallengesPaths::NODE_PATH)->play();
-
+        $docker->bindMount(storage_path(LocalChallengesPaths::NODE_PATH), DockerChallengesPaths::NODE_PATH)->detach()->play();
+        g
         $writer = new StorageWriter(StorageDisks::LOCAL_DISK, true,
             ["ChallengesTests", 'javascript', $challenge->id, $userIdentifier]);
 
@@ -59,7 +59,7 @@ class CodeRunnerController extends Controller
         $docker = new DockerContainer("node-" . $userIdentifier, DockerImagesNames::NODE_IMAGE);
 
 
-        $docker->exec("sh -c 'npm run test tests/$challenge->id/$userIdentifier/func.test.js -- --json"
+        $docker->detach()->exec("sh -c 'npm run test tests/$challenge->id/$userIdentifier/func.test.js -- --json"
             . "> tests/$challenge->id/$userIdentifier/test.json'");
 
         // npm run jest -- --json return a string with 4 extra unnecessary lines, just trim them

--- a/app/Http/Requests/Api/v1/StoreChallengeRequest.php
+++ b/app/Http/Requests/Api/v1/StoreChallengeRequest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Http\Requests\Api\v1;
+
+use App\Constants\ChallengeDifficulties;
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreChallengeRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => 'required|min:5|unique:challenges',
+            'description' => 'required|min:10',
+            'time_out' => 'required',
+            'difficulty' => 'required|min:3',
+            'func_template' => 'required|min:10',
+            'test_template' => 'required|min:10',
+        ];
+    }
+}

--- a/app/Models/Challenge.php
+++ b/app/Models/Challenge.php
@@ -13,7 +13,8 @@ class Challenge extends Model
     use HasFactory;
 
     protected $fillable = [
-        'name', 'description', 'time_out', 'difficult'
+        'name', 'description', 'time_out', 'difficulty',
+        'func_template', 'test_template',
     ];
 
     public function challengers(): BelongsToMany

--- a/app/Services/DockerContainer.php
+++ b/app/Services/DockerContainer.php
@@ -42,6 +42,7 @@ class DockerContainer
     public function detach()
     {
         $this->detachable = true;
+        return $this;
     }
 
     public function bindMount($localStorageBind, $dockerStorageBind): DockerContainer

--- a/routes/api.php
+++ b/routes/api.php
@@ -24,10 +24,8 @@ Route::prefix("v1")->group(function () {
     Route::apiResource('achievements', App\Http\Controllers\Api\V1\AchievementController::class);
     Route::apiResource('challengers', ChallengerController::class)->only('show');
     Route::get('challengers/{challenger}/challenges', [ChallengerController::class, 'challenges'])->name('challengers.challenges');
-    Route::apiResource('challenges', ChallengeController::class)->only('index', 'show');
+    Route::apiResource('challenges', ChallengeController::class)->only('index', 'show', 'store');
     Route::apiResource('ranks', App\Http\Controllers\Api\V1\RankController::class);
-
-
     Route::prefix("runner/")->group(function () {
         Route::get('/on/{challenge}', [App\Http\Controllers\CodeRunnerController::class, 'getChallengeEditor']);
         Route::post('/check/{challenge}', [App\Http\Controllers\CodeRunnerController::class, 'runNode']);

--- a/tests/Feature/Api/V1/ChallengesControllerTest.php
+++ b/tests/Feature/Api/V1/ChallengesControllerTest.php
@@ -56,4 +56,33 @@ class ChallengesControllerTest extends TestCase
             'challengers_has_completed' => [['challenger', 'points', 'rank']],
         ]]);
     }
+
+    public function test_store_challenge()
+    {
+        $data = [
+            'name' => 'random',
+            'description' => 'Get a random number',
+            'time_out' => '15',
+            'difficulty' => 'low',
+            'func_template' => 'function random($min, $max) {
+                return rand($min, $max);
+            }',
+            'test_template' => 'function test($min, $max) {
+                return random($min, $max) == rand($min, $max);
+            }',
+
+        ];
+
+        $response = $this->post('/api/v1/challenges', array_merge($data, ['token' => 'h2405kal2rnk123']));
+        $response->assertStatus(201);
+
+        $response->assertJsonStructure(["data" => [
+            'id',
+            'name',
+            'description',
+            'time_out',
+            'challengers_has_completed' => [],
+        ]]);
+        $this->assertDatabaseHas('challenges', $data);
+    }
 }


### PR DESCRIPTION
## Store endpoint for challenges

Related endpoint: `Post -> api/v1/challenges `


Now we can store new challenges from an endpoint

right now I'm validating a fake token, then it will be updated with a token of authorized users

resolves #45

<!-- Thanks so much for your PR, your contribution is appreciated! -->

## Checklist ✅

- [x] I have followed the [contributor guideline](https://github.com/Platzi-Master-C8/gethired-base/blob/main/CONTRIBUTING.md)
- [x] Tests are included
- [x] Documentation is changed or added
- [x] Related issue has been created
- [x] Commits messages follows [commit guideline](https://github.com/Platzi-Master-C8/gethired-base/blob/main/CONTRIBUTING.md/#Commits)

resolves #45 
<!-- Replace [Issue ID] with the issue id -->